### PR TITLE
ENG-693 Changed _delete_by_query to be POST to _delete_by_query

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tornado>4
-elasticsearch>=2.3
+elasticsearch>=5.0

--- a/tornado_elasticsearch.py
+++ b/tornado_elasticsearch.py
@@ -834,10 +834,10 @@ class AsyncElasticsearch(Elasticsearch):
         :arg q: Query in the Lucene query string syntax
         :arg timeout: Explicit operation timeout
         """
-        _, data = yield self.transport.perform_request('DELETE',
+        _, data = yield self.transport.perform_request('POST',
                                                        _make_path(index,
                                                                   doc_type,
-                                                                  '_query'),
+                                                                  '_delete_by_query'),
                                                        params=params, body=body)
         raise gen.Return(data)
 


### PR DESCRIPTION
This changes the _delete_by_query function from a "DELETE to _query" to be a "POST to _delete_by_query" as it was changed in 5.0

If it is desired to push this to the upstream library, then some checking of versions might have to be done.  after 2 and before 5 it will have to be the old DELETE to _query
